### PR TITLE
Implement the `/scanner/updateStatus` post action

### DIFF
--- a/changelog/@unreleased/pr-10.v2.yml
+++ b/changelog/@unreleased/pr-10.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Implement the /scanner/updateStatus post action
+  links:
+  - https://github.com/palantir/tenablesc-client/pull/10

--- a/tenablesc/scanner.go
+++ b/tenablesc/scanner.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 )
 
-const scannerEndpoint = "/scanner"
+const (
+	scannerEndpoint    = "/scanner"
+	updateScanEndpoint = "/updateStatus"
+)
 
 type Scanner struct {
 	BaseInfo
@@ -17,6 +20,27 @@ func (c *Client) GetAllScanners() ([]*Scanner, error) {
 
 	if _, err := c.getResource(scannerEndpoint, &resp); err != nil {
 		return nil, fmt.Errorf("could not get scanners: %w", err)
+	}
+
+	return resp, nil
+}
+
+type UpdateScannersStatus struct {
+	Status []struct {
+		BaseInfo
+		Status string `json:"status"`
+	} `json:"status"`
+}
+
+func (c *Client) UpdateScanners() (*UpdateScannersStatus, error) {
+	var resp *UpdateScannersStatus
+
+	if _, err := c.postResource(
+		fmt.Sprintf("%s%s", scannerEndpoint, updateScanEndpoint),
+		nil,
+		&resp,
+	); err != nil {
+		return nil, fmt.Errorf("could not update scanner status: %w", err)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Hello and thanks for putting the cycles into the `tenablesc-client` repo! We're excited to start using it, but we have the need for a few more endpoints. Hopefully the stuff that we need can help others! 
 
Per the docs [here](https://docs.tenable.com/tenablesc/api/Scanner.htm#ScannerRESTReference-/scanner/updateStatus), this PR implements the `/scanner/updateStatus` post action.

I'm happy to support any feedback.