### PR TITLE
Implement delete functions for credential and scanresult endpoints

### DIFF
--- a/changelog/@unreleased/pr-21.yml
+++ b/changelog/@unreleased/pr-21.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Implement the credential and scanresult delete action
+  links:
+    - https://github.com/palantir/tenablesc-client/pull/21

--- a/tenablesc/credential.go
+++ b/tenablesc/credential.go
@@ -7,7 +7,7 @@ import (
 const credentialEndpoint = "/credential"
 
 // Credential is massively pared back from the possible types in https://docs.tenable.com/tenablesc/api/Credential.htm
-// This is not wired to directly manage credentials, only to find them.
+// This is not wired to directly manage credentials, only to find and delete them.
 type Credential struct {
 	BaseInfo
 	Type      string   `json:"type"`
@@ -54,4 +54,12 @@ func (c *Client) GetCredential(id string) (*Credential, error) {
 	}
 
 	return resp, nil
+}
+
+func (c *Client) DeleteCredential(id string) error {
+	if _, err := c.deleteResource(fmt.Sprintf("%s/%s", credentialEndpoint, id), nil, nil); err != nil {
+		return fmt.Errorf("unable to delete credential with id %s: %w", id, err)
+	}
+
+	return nil
 }

--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -102,6 +102,14 @@ func (c *Client) GetScanResult(id string) (*ScanResult, error) {
 	return &resp, nil
 }
 
+func (c *Client) DeleteScanResult(id string) error {
+	if _, err := c.deleteResource(fmt.Sprintf("%s/%s", scanResultEndpoint, id), nil, nil); err != nil {
+		return fmt.Errorf("unable to delete scan result with id %s: %w", id, err)
+	}
+
+	return nil
+}
+
 func (c *Client) DownloadScanResult(id string) ([]byte, error) {
 
 	possiblyZippedStream, err := c.internalDownloadScanResult(id)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We have a need to programmatically delete credentials and scan results. Currently this functionality is not implemented. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Users will now be able to delete credentials and scan results by ID.

## Possible downsides?
None that I'm aware of.
