### PR TITLE
Allow SSH cert credentials to be created and modified

### DIFF
--- a/changelog/@unreleased/pr-27.v2.yml
+++ b/changelog/@unreleased/pr-27.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Allow SSH cert credentials to be created and modified.
+  links:
+    - https://github.com/palantir/tenablesc-client/pull/27

--- a/tenablesc/credential.go
+++ b/tenablesc/credential.go
@@ -63,3 +63,74 @@ func (c *Client) DeleteCredential(id string) error {
 
 	return nil
 }
+
+// SSHCertificateCredentialUpload https://docs.tenable.com/tenablesc/api/Credential.htm#credential_POST
+type SSHCertificateCredentialUpload struct {
+	BaseInfo
+	Tags                string `json:"tags"`
+	Type                string `json:"type"`
+	Username            string `json:"username"`
+	AuthType            string `json:"authType"`
+	PublicKey           string `json:"publicKey"`
+	PrivateKey          string `json:"privateKey"`
+	PrivilegeEscalation string `json:"privilegeEscalation"`
+}
+
+// handleSSHCertCredFileUpload takes a key as a string and uploads it as a new file to tenable.sc.
+// it returns the name of the fie that it is stored as on tenable.sc.
+// this file name is used as a reference when creating or modifying SSH certificate credentials
+func (c *Client) handleSSHCertCredFileUpload(key string) (string, error) {
+	keyFile, err := c.UploadFileFromString(key, "key", "")
+	if err != nil {
+		return "", fmt.Errorf("unable to upload key file: %w", err)
+	}
+	return keyFile.Filename, nil
+}
+
+// AddSSHCertificateCredential does the following:
+// 1. takes a public key and private key as strings and uploads those to tenable.sc
+// 2. for both private and public keys it stores the file name in PublicKey and PrivateKey in SSHCertificateCredentialUpload
+// 3. post the cred to tenable.sc and return the object
+func (c *Client) AddSSHCertificateCredential(publicKey, privateKey string, sshCertCred SSHCertificateCredentialUpload) (*Credential, error) {
+	var err error
+	sshCertCred.PrivateKey, err = c.handleSSHCertCredFileUpload(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload private key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	sshCertCred.PublicKey, err = c.handleSSHCertCredFileUpload(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload public key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	resp := &Credential{}
+	if _, err := c.postResource(credentialEndpoint, sshCertCred, resp); err != nil {
+		return nil, fmt.Errorf("failed to create ssh cert credential: %w", err)
+	}
+
+	return resp, nil
+}
+
+// UpdateSSHCertificateCredential does the following:
+// 1. takes a public key and private key as strings and uploads those to tenable.sc
+// 2. for both private and public keys it stores the file name in PublicKey and PrivateKey in SSHCertificateCredentialUpload
+// 3. patches the cred to tenable.sc and return the object
+func (c *Client) UpdateSSHCertificateCredential(publicKey, privateKey string, sshCertCred SSHCertificateCredentialUpload) (*Credential, error) {
+	var err error
+	sshCertCred.PrivateKey, err = c.handleSSHCertCredFileUpload(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload private key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	sshCertCred.PublicKey, err = c.handleSSHCertCredFileUpload(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to upload public key credential for credential name %s: %w", sshCertCred.Name, err)
+	}
+
+	resp := &Credential{}
+	if _, err := c.patchResourceWithID(credentialEndpoint, sshCertCred, resp); err != nil {
+		return nil, fmt.Errorf("failed to update ssh cert credential: %w", err)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We are unable to add and modify SSH cert credentials.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
We can now add and modify SSH cert credentials.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None that I can see. 


I'm happy to address any comments or recommendations for this PR. Thanks for taking the time to look it over! I have tested it and it is functioning as expected against tenable.sc Version: 5.20.1.

