### PR TITLE
Fix get all scan results by time

### DIFF
--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -56,7 +56,7 @@ type ScanResult struct {
 
 type scanResultInternal struct {
 	Manageable []*ScanResult `json:"manageable" tenable:"recurse"`
-	Useable    []*ScanResult `json:"useable" tenable:"recurse"`
+	Usable     []*ScanResult `json:"usable" tenable:"recurse"`
 }
 
 // Do the usable/manageable split thing. ffff.

--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -75,7 +75,7 @@ func (c *Client) GetAllScanResultsByTime(start, end time.Time) ([]*ScanResult, e
 		v.Add("startTime", fmt.Sprintf("%d", start.Unix()))
 	}
 	if !end.IsZero() {
-		v.Add("endTime", fmt.Sprintf("%d", start.Unix()))
+		v.Add("endTime", fmt.Sprintf("%d", end.Unix()))
 	}
 
 	resourceURL := strings.Builder{}


### PR DESCRIPTION
## Before this PR
It was not possible to control interval of exported scan results.
ScanResult "usable" JSON field had a typo ("useable").

## After this PR
GetAllScanResultsByTime() function properly deals with the requested time interval.
ScanResult "usable" JSON field is correctly spelled.

## Possible downsides?
N/A

