### PR TITLE
scanresult: return both manageable and usable scan results

### DIFF
--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -90,7 +90,10 @@ func (c *Client) GetAllScanResultsByTime(start, end time.Time) ([]*ScanResult, e
 		return nil, fmt.Errorf("failed to get scan results: %w", err)
 	}
 
-	return resp.Manageable, nil
+	ret := resp.Manageable
+	ret = append(ret, resp.Useable...)
+
+	return ret, nil
 }
 
 func (c *Client) GetScanResult(id string) (*ScanResult, error) {


### PR DESCRIPTION
## Before this PR
Only "manageable" scan results were returned. Whereas "usable" scan results may be needed.

## After this PR
GetAllScanResultsByTime() merges usable and manageable scan results.

## Possible downsides?
API consumer may expect both sets of scan results returned independently.

