### PR TITLE
add newly introduced attributes State+Type for ScanPolicy's Plugin Family

### DIFF
--- a/changelog/@unreleased/pr-40.v2.yml
+++ b/changelog/@unreleased/pr-40.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: add newly introduced attributes State+Type for ScanPolicy's Plugin
+    Family
+  links:
+  - https://github.com/palantir/tenablesc-client/pull/40

--- a/tenablesc/scanpolicy.go
+++ b/tenablesc/scanpolicy.go
@@ -28,6 +28,8 @@ type ScanPolicyFamilies struct {
 	ID      string     `json:"id"`
 	Name    string     `json:"name,omitempty"`
 	Count   string     `json:"count,omitempty"`
+	State   string     `json:"state,omitempty"`
+	Type    string     `json:"type,omitempty"`
 	Plugins []BaseInfo `json:"plugins,omitempty"`
 }
 


### PR DESCRIPTION
## Before this PR
Tenable SC6 is introducing new attributes(State+Type) for scan policy's plugin family, and we want to ensure they can be configured in our API requests and responses. 
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Add newly introduced attributes State+Type for ScanPolicy's Plugin Family

## Possible downsides?
None
