### PR TITLE
Improving ScanResult functionality

### DIFF
--- a/_examples/scanresult/main.go
+++ b/_examples/scanresult/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/palantir/tenablesc-client/tenablesc"
+)
+
+func main() {
+	client := tenablesc.NewClient(
+		os.Getenv("TENABLE_URL"), // Tenable SC host. ensure the url has /rest in their path.
+	).SetAPIKey(
+		os.Getenv("TENABLE_ACCESS_KEY"), // Tenable SC access key.
+		os.Getenv("TENABLE_SECRET_KEY"), // Tenable SC secret key.
+	)
+
+	now := time.Now()
+	dayBefore := now.Add(-1 * 24 * time.Hour)
+	scans, err := client.GetAllScanResultsByTime(dayBefore, now)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("listing scan results for the past 24 hours")
+	for _, scan := range scans {
+		log.Println(scan.Name, scan.ID)
+	}
+
+	firstScanResult := scans[0]
+	log.Printf("get scan result for ID: %s\n", firstScanResult.ID)
+	result, err := client.GetScanResult(string(firstScanResult.ID))
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("scan result name returned:", result.Name)
+
+	log.Printf("downloading scan results for ID: %s\n", firstScanResult.ID)
+	outFileName := fmt.Sprintf("scan-results-%s.nessus", firstScanResult.ID)
+	downloadedData, err := client.DownloadScanResult(string(firstScanResult.ID))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("writing downloaded data to file: %s", outFileName)
+	err = os.WriteFile(outFileName, downloadedData, os.FileMode(0600))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}

--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Improving ScanResult functionality
+  links:
+  - https://github.com/palantir/tenablesc-client/pull/74

--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -67,23 +66,20 @@ func (c *Client) GetAllScanResults() ([]*ScanResult, error) {
 
 func (c *Client) GetAllScanResultsByTime(start, end time.Time) ([]*ScanResult, error) {
 
-	v := url.Values{}
-
+	params := url.Values{}
 	if !start.IsZero() {
-		v.Add("startTime", fmt.Sprintf("%d", start.Unix()))
+		params.Add("startTime", fmt.Sprintf("%d", start.Unix()))
 	}
 	if !end.IsZero() {
-		v.Add("endTime", fmt.Sprintf("%d", end.Unix()))
+		params.Add("endTime", fmt.Sprintf("%d", end.Unix()))
 	}
 
-	resourceURL := strings.Builder{}
-	resourceURL.WriteString(scanResultEndpoint)
-	if len(v) > 0 {
-		resourceURL.WriteString(fmt.Sprintf("?%s", v.Encode()))
+	resourceURL := url.URL{
+		Path:     scanResultEndpoint,
+		RawQuery: params.Encode(),
 	}
 
 	var resp scanResultInternal
-
 	if _, err := c.getResource(resourceURL.String(), &resp); err != nil {
 		return nil, fmt.Errorf("failed to get scan results: %w", err)
 	}
@@ -106,7 +102,7 @@ func (c *Client) GetAllScanResultsByTime(start, end time.Time) ([]*ScanResult, e
 }
 
 func (c *Client) GetScanResult(id string) (*ScanResult, error) {
-	resp := ScanResult{}
+	var resp ScanResult
 	if _, err := c.getResource(fmt.Sprintf("%s/%s", scanResultEndpoint, id), &resp); err != nil {
 		return nil, fmt.Errorf("failed to get scan result %s: %w", id, err)
 	}

--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -177,7 +177,7 @@ func firstFileFromPKZipSlice(slice []byte) ([]byte, error) {
 
 	reader, err := zip.NewReader(bytes.NewReader(slice), int64(len(slice)))
 	if err != nil {
-		return nil, fmt.Errorf("nessus scan result zip could not be parsed: %w", err)
+		return nil, fmt.Errorf("failed to create zip reader: %w", err)
 	}
 
 	if len(reader.File) == 0 {
@@ -189,7 +189,7 @@ func firstFileFromPKZipSlice(slice []byte) ([]byte, error) {
 		return nil, fmt.Errorf("could not open first file in zip: %w", err)
 	}
 
-	results, err = ioutil.ReadAll(file)
+	results, err = io.ReadAll(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read zip file: %w", err)
 	}

--- a/tenablesc/scanresult.go
+++ b/tenablesc/scanresult.go
@@ -75,7 +75,7 @@ func (c *Client) GetAllScanResultsByTime(start, end time.Time) ([]*ScanResult, e
 		v.Add("startTime", fmt.Sprintf("%d", start.Unix()))
 	}
 	if !end.IsZero() {
-		v.Add("endTime", fmt.Sprintf("%d", start.Unix()))
+		v.Add("endTime", fmt.Sprintf("%d", end.Unix()))
 	}
 
 	resourceURL := strings.Builder{}


### PR DESCRIPTION
### Changes
* Ensure that usable scan results are correctly unmarshalled.
* Ensure that the scan results response returns managable and usable scans.
* Update deprecated functions in scan results.
* Add an example of scan results functionality.
* Use `url.Values` instead of string builder to handle constructing query parameters.
* Ensure that the `endTime ` is correctly passed to the API call.