### PR TITLE
allow access to the underlying resty client

### DIFF
--- a/_examples/restyclient/main.go
+++ b/_examples/restyclient/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"os"
+
+	"github.com/palantir/tenablesc-client/tenablesc"
+)
+
+func main() {
+	client := tenablesc.NewClient(
+		os.Getenv("TENABLE_URL"), // Tenable SC host. ensure the url has /rest in their path.
+	).SetAPIKey(
+		os.Getenv("TENABLE_ACCESS_KEY"), // Tenable SC access key.
+		os.Getenv("TENABLE_SECRET_KEY"), // Tenable SC secret key.
+	)
+
+	// Configuring the client's minimum TLS version to be TLS v1.2
+	client.RestyClient().SetTLSClientConfig(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})
+
+	_, err := client.GetCurrentUser()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/changelog/@unreleased/pr-76.v2.yml
+++ b/changelog/@unreleased/pr-76.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow access to the underlying resty client
+  links:
+  - https://github.com/palantir/tenablesc-client/pull/76

--- a/tenablesc/client.go
+++ b/tenablesc/client.go
@@ -28,13 +28,12 @@ type response struct {
 //
 //	Don't forget to SetAPIKey or SetBasicAuth to ensure you make credentialed queries.
 func NewClient(baseURL string) *Client {
-
-	c := resty.New().
+	client := resty.New().
 		SetBaseURL(baseURL).
 		SetHeader(http.CanonicalHeaderKey("User-Agent"), DefaultUserAgent).
 		AddRetryCondition(defaultTenableRetryConditions)
 
-	return &Client{*c}
+	return &Client{*client}
 }
 
 // SetAPIKey adds the API Key header to all queries with the client.
@@ -56,6 +55,12 @@ func (c *Client) SetBasicAuth(username, password string) *Client {
 func (c *Client) SetUserAgent(agent string) *Client {
 	c.client.SetHeader(http.CanonicalHeaderKey("User-Agent"), agent)
 	return c
+}
+
+// RestyClient returns a pointer to the underlying resty.Client instance.
+// This enables access to all the features and options provided by the resty library.
+func (c *Client) RestyClient() *resty.Client {
+	return &c.client
 }
 
 func defaultTenableRetryConditions(resp *resty.Response, err error) bool {


### PR DESCRIPTION
### Overview:
Adding a new method `RestyClient()` to allow access to the underlying resty client. The consumer will have the ability to utilize any available option defined by Resty library.

