### PR TITLE
Add inactivityTimeout to scan struct

### DIFF
--- a/changelog/@unreleased/pr-86.yml
+++ b/changelog/@unreleased/pr-86.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add inactivityTimeout to scan struct
+  links:
+  - https://github.com/palantir/tenablesc-client/pull/86

--- a/tenablesc/scan.go
+++ b/tenablesc/scan.go
@@ -17,6 +17,7 @@ type Scan struct {
 	DHCPTracking         FakeBool            `json:"dhcpTracking,omitempty"`
 	EmailOnFinish        FakeBool            `json:"emailOnFinish,omitempty"`
 	EmailOnLaunch        FakeBool            `json:"emailOnLaunch,omitempty"`
+	InactivityTimeout    string              `json:"inactivityTimeout,omitempty"`
 	IPList               string              `json:"ipList,omitempty"`
 	MaxScanTime          string              `json:"maxScanTime,omitempty"`
 	ModifiedTime         UnixEpochStringTime `json:"modifiedTime,omitempty"`


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently we're unable to set the `inactivityTimeout` field when creating a new scan.

## After this PR
We'll be able to set the `inactivityTimeout` field when creating a new scan.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Nope!
