### PR TITLE
Add EPSS, exploit framework, CISA KEV, and scoring fields to Plugin and analysis structs

### DIFF
--- a/tenablesc/analysis.go
+++ b/tenablesc/analysis.go
@@ -66,6 +66,7 @@ type AnalysisResponseContainer struct {
 
 // VulnSumIPResult contains the structure used by the 'sumip' analysis tool.
 type VulnSumIPResult struct {
+	ACRScore         string         `json:"acrScore"`
 	BiosGUID         string         `json:"biosGUID"`
 	DNSName          string         `json:"dnsName"`
 	IP               string         `json:"ip"`
@@ -118,6 +119,7 @@ type VulnIPSummaryResult struct {
 // VulnDetailsResult contains the structure used by the 'vulndetails' analysis tool
 type VulnDetailsResult struct {
 	AcceptRisk          string         `json:"acceptRisk"`
+	ACRScore            string         `json:"acrScore"`
 	BaseScore           string         `json:"baseScore"`
 	BID                 string         `json:"bid"`
 	CheckType           string         `json:"checkType"`
@@ -132,6 +134,7 @@ type VulnDetailsResult struct {
 	ExploitAvailable    string         `json:"exploitAvailable"`
 	ExploitEase         string         `json:"exploitEase"`
 	ExploitFrameworks   string         `json:"exploitFrameworks"`
+	EPSSScore           string         `json:"epssScore"`
 	Family              VulnFamily     `json:"family"`
 	FirstSeen           string         `json:"firstSeen"`
 	HasBeenMitigated    string         `json:"hasBeenMitigated"`

--- a/tenablesc/plugin.go
+++ b/tenablesc/plugin.go
@@ -11,8 +11,25 @@ const pluginEndpoint = "/plugin"
 type Plugin struct {
 	BaseInfo
 	Family              Family         `json:"family,omitempty"`
+	Synopsis            string         `json:"synopsis,omitempty"`
+	Solution            string         `json:"solution,omitempty"`
+	SeeAlso             string         `json:"seeAlso,omitempty"`
+	CPE                 string         `json:"cpe,omitempty"`
+	RiskFactor          string         `json:"riskFactor,omitempty"`
+	CVSSVector          string         `json:"cvssVector,omitempty"`
+	BaseScore           string         `json:"baseScore,omitempty"`
+	TemporalScore       string         `json:"temporalScore,omitempty"`
 	CVSSV3BaseScore     string         `json:"cvssV3BaseScore,omitempty"`
 	CVSSV3TemporalScore string         `json:"cvssV3TemporalScore,omitempty"`
+	CVSSV3Vector        string         `json:"cvssV3Vector,omitempty"`
+	VPRScore            string         `json:"vprScore,omitempty"`
+	VPRContext          string         `json:"vprContext,omitempty"`
+	EPSSScore           string         `json:"epssScore,omitempty"`
+	StigSeverity        string         `json:"stigSeverity,omitempty"`
+	ExploitAvailable    string         `json:"exploitAvailable,omitempty"`
+	ExploitEase         string         `json:"exploitEase,omitempty"`
+	ExploitFrameworks   string         `json:"exploitFrameworks,omitempty"`
+	XRefs               string         `json:"xrefs,omitempty"`
 	PluginPubDate       ProbablyString `json:"pluginPubDate,omitempty"`
 	PluginModDate       ProbablyString `json:"pluginModDate,omitempty"`
 	PatchPubDate        ProbablyString `json:"patchPubDate,omitempty"`


### PR DESCRIPTION
## Before this PR

The `Plugin` struct only maps 12 of the 40+ fields the Tenable.SC `/plugin/{id}` API returns. Several fields needed for vulnerability metadata enrichment are missing entirely:

- `epssScore` (EPSS — Exploit Prediction Scoring System) is not mapped in any struct
- `exploitFrameworks`, `cpe`, `xrefs`, `vprScore`, `vprContext` are available in `VulnDetailsResult` (analysis) but not in `Plugin` (direct plugin lookups)
- `acrScore` (Asset Criticality Rating) is not mapped anywhere despite being returned by the analysis endpoint

This makes it impossible to access EPSS scores, exploit framework details, CISA Known Exploited Vulnerability (KEV) entries (embedded in `xrefs`), or asset criticality through this client library.

## After this PR

**`Plugin` struct** — 15 new fields added, matching the Tenable.SC Plugin API response:

| Field | JSON Key | Purpose |
|-------|----------|---------|
| `EPSSScore` | `epssScore` | Exploit Prediction Scoring System score |
| `ExploitFrameworks` | `exploitFrameworks` | Canvas, Metasploit, Core Impact, etc. |
| `CPE` | `cpe` | Common Platform Enumeration identifier |
| `XRefs` | `xrefs` | Cross-references incl. CISA-KNOWN-EXPLOITED entries |
| `VPRScore` | `vprScore` | Vulnerability Priority Rating score |
| `VPRContext` | `vprContext` | VPR threat intelligence context (JSON) |
| `ExploitAvailable` | `exploitAvailable` | Whether public exploits exist |
| `ExploitEase` | `exploitEase` | Exploit difficulty descriptor |
| `RiskFactor` | `riskFactor` | Risk factor (Critical/High/Medium/Low/None) |
| `Synopsis` | `synopsis` | Short vulnerability summary |
| `Solution` | `solution` | Remediation guidance |
| `SeeAlso` | `seeAlso` | Reference URLs |
| `CVSSVector` | `cvssVector` | CVSS v2 vector string |
| `BaseScore` | `baseScore` | CVSS v2 base score |
| `TemporalScore` | `temporalScore` | CVSS v2 temporal score |
| `CVSSV3Vector` | `cvssV3Vector` | CVSS v3 vector string |
| `StigSeverity` | `stigSeverity` | DISA STIG severity rating |

All new fields use `string` type with `omitempty`, consistent with existing patterns. Since `getFieldsForStruct` auto-builds the `?fields=` query parameter from struct tags, the new fields are automatically requested from the API — no changes to `GetPlugin` or `GetPluginsByName` needed.

**`VulnDetailsResult` struct** — 2 new fields:
- `EPSSScore` (`epssScore`) — EPSS score per vulnerability finding
- `ACRScore` (`acrScore`) — Asset Criticality Rating of the host where the finding was observed

**`VulnSumIPResult` struct** — 1 new field:
- `ACRScore` (`acrScore`) — Asset Criticality Rating per host in summary view

## Possible downsides?

- No breaking changes. All new fields are additive.
- Existing consumers of `Plugin` will now receive more fields in API responses due to `getFieldsForStruct` requesting them. This increases response payload size slightly but should not affect behavior since unknown JSON fields are silently ignored by `encoding/json`.
- CVSSv4 fields (`cvssV4Vector`, `cvssV4BaseScore`, etc.) available in the Plugin API are intentionally deferred — they can be added in a follow-up.