### PR TITLE
Allow universal data format in repository.go

### DIFF
--- a/tenablesc/repository.go
+++ b/tenablesc/repository.go
@@ -82,7 +82,7 @@ func (r repoInternal) toExternal() (*Repository, error) {
 		return nil, fmt.Errorf("faild to unmarshal typeFields: %w", err)
 	}
 
-	if strings.HasPrefix(r.DataFormat, "IP") {
+	if strings.HasPrefix(r.DataFormat, "IP") || r.DataFormat == "universal" {
 		if err := json.Unmarshal(r.TypeFields, &repo.RepoIPFields); err != nil {
 			return nil, fmt.Errorf("faild to unmarshal typeFields: %w", err)
 		}


### PR DESCRIPTION
Support for universal data format introduced in Tenable SC version 6.8

## Before this PR
Tenable Security Center 6.8 introduced support for the Universal Data Format (UDF), enabling unified asset repositories and scan data handling across IPv4, IPv6, and Agent-based assets. However, the Terraform provider did not support the new UDF-related API fields and repository types introduced in Security Center 6.8.

As a result, users running Tenable SC 6.8 were unable to fully manage or import UDF-enabled resources through Terraform, leading to compatibility issues and preventing adoption of the latest Security Center features.

## After this PR
This PR adds support for the Universal Data Format (UDF) introduced in Tenable Security Center 6.8.
==COMMIT_MSG==
Add support for Universal Data Format (UDF) introduced in Tenable SC 6.8
==COMMIT_MSG==

## Possible downsides?
* Users running older versions of Tenable Security Center may encounter behavioral differences if API responses vary between releases.
* Additional testing may be required in mixed-version environments where both pre-6.8 and 6.8+ Security Center instances are managed.
* Any future changes to the UDF API model may require further provider updates.

